### PR TITLE
update to add "--talk-name=org.kde.kwalletd5" permission.

### DIFF
--- a/io.github.mhogomchungu.sirikali.json
+++ b/io.github.mhogomchungu.sirikali.json
@@ -12,6 +12,7 @@
     "--share=network",
     "--device=dri",
     "--talk-name=org.kde.StatusNotifierWatcher",
+    "--talk-name=org.kde.kwalletd5",
     "--talk-name=org.freedesktop.Flatpak"
   ],
   "modules" : [


### PR DESCRIPTION
Mentioned permission is required to allow the application to access kwallet to store user passwords.